### PR TITLE
Update response descriptions to title case

### DIFF
--- a/i3-geocode-conversion.yaml
+++ b/i3-geocode-conversion.yaml
@@ -20,7 +20,7 @@ paths:
         required: true
       responses:
         '200':
-          description: Data successfully converted
+          description: Data Successfully Converted
           content:
             application/xml:
               schema:
@@ -54,7 +54,7 @@ paths:
         required: true
       responses:
         '200':
-          description: Data successfully converted
+          description: Data Successfully Converted
           content:
             application/xml:
               schema:
@@ -67,6 +67,8 @@ paths:
               schema:
                 type: string
                 format: uri
+        '454':
+          description: Unspecified Error
         '468':
           description: No Address Found
         '469':
@@ -82,7 +84,7 @@ paths:
       operationId: RetrieveVersions
       responses:
         '200':
-          description: Versions found
+          description: Versions Found
           content:
             application/json:
               schema:


### PR DESCRIPTION
Note I added 454 Unspecified Error to the ReverseGeocode endpoint as Guy added it to the Word doc in his contribution. The note in his Word doc contribution was that the addition came from the YAML. Obviously the Word doc and YAML should agree, so I've added it to be consistent with his contribution. If that's controversial, I can remove it from the YAML.